### PR TITLE
Start wget asyncronously

### DIFF
--- a/wget_course_pages.sh
+++ b/wget_course_pages.sh
@@ -10,6 +10,6 @@ while read code; do
     if [[ -f "./html/$code.html" ]]; then 
         echo "$code already downloaded."
     else 
-        wget 'https://my.uq.edu.au/programs-courses/course.html?course_code='"$code" -O "./html/$code".html
+        wget 'https://my.uq.edu.au/programs-courses/course.html?course_code='"$code" -O "./html/$code".html &
     fi
 done < "$course_codes"


### PR DESCRIPTION
Starts a new `wget` process for each course. 
No need to wait for the current `wget` process to fetch and save the file.